### PR TITLE
add `dxcbash` custom function

### DIFF
--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -87,6 +87,7 @@ zstyle ':omz:plugins:docker' legacy-completion yes
 
 ## Custom functions (pseudo-aliases)
 
-| Name  | Function                                   | Description                                               |
-| :---- | :----------------------------------------- | :-------------------------------------------------------- |
-| dxcsh | `dxcsh() { docker exec -it "$@" /bin/sh }` | Run a interactive shell inside a running docker container |
+| Name    | Function                                       | Description                                               |
+| :------ | :--------------------------------------------- | :-------------------------------------------------------- |
+| dxcsh   | `dxcsh() { docker exec -it "$@" /bin/sh }`     | Run a interactive shell inside a running docker container |
+| dxcbash | `dxcbash() { docker exec -it "$@" /bin/bash }` | Run a interactive bash inside a running docker container  |

--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -41,6 +41,7 @@ alias dxc='docker container exec'
 alias dxcit='docker container exec -it'
 
 dxcsh() { docker exec -it "$@" /bin/sh }
+dxcbash() { docker exec -it "$@" /bin/bash }
 
 if (( ! $+commands[docker] )); then
   return


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

Not applicable, I don't think =)

## Changes:

- Added function `dxcbash` for simple run a bash inside a running docker container
